### PR TITLE
Beta: Copy Page Content to Tana Paste, improved docs, and consolidated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,147 +1,15 @@
 # Tana Tools for Raycast Changelog
 
-## [2.1.0] - 2025-05-24
-
-### Added
-- The "Convert Selected Text to Tana" command now automatically adds a URL field and the #swipe supertag when text is selected from a web page.
-- The URL is placed above the selected text as a child node under the page title.
-- The page title is used as the parent node for the selection when available.
-
-## [2.0.0] - 2025-05-07
-
-### Added
-
-- Comprehensive documentation for the Tana converter module
-
-### Changed
-
-- Complete refactoring of the Tana converter into a modular architecture
-- Enhanced date formatting with improved pattern recognition and conversion
-- Improved text formatting capabilities
-- Optimized transcript processing with dedicated module
-- Better type definitions for improved code maintainability
-
-## [1.6.1] - 2025-05-06
-
-### Changed
-
-- Updated project structure to comply with Raycast store requirements
-- Removed Python script dependency for streamlined installation
-- Improved documentation for clarity and focus on Raycast extension functionality
-- Updated ESLint configuration to match Raycast recommendations
-
-## [1.6.0] - 2025-04-18
-
-### Added
-
-- Enhanced YouTube transcript processing with improved formatting (#33)
-- Added transcript chunking functionality for better organization
-- Enhanced Limitless Pendant transcription processing
-- Added Limitless App transcription support
-
-## [1.5.4] - 2025-04-17
-
-### Fixed
-
-- Fixed incorrect indentation in Tana converter that was causing all content to be placed under a single node (#27)
-- Fixed bullet point conversion for mixed format lists (#24)
-  - Fixed nested bullets not being properly separated
-  - Added support for multiple bullet formats (numbers, symbols, letters)
-  - Improved handling of nested bullet points
-  - Added proper indentation for mixed format lists
-
-## [1.5.2] - 2025-04-13
-
-### Changed
-
-- Updated extension icon
-
-## [1.5.1] - 2025-04-13
-
-### Added
-
-- Transcript extraction for YouTube videos in the YouTube to Tana command (into Transcript field)
-- Graceful fallback when transcript is unavailable
-
-## [1.5.0] - 2025-04-13
-
-### Added
-
-- YouTube to Tana command to extract video metadata and convert to Tana format (#15)
-- Support for extracting video title, URL, channel, author and description from YouTube pages
-
-## [1.4.3] - 2025-04-08
-
-### Changed
-
-- Updated memory bank with correct GitHub CLI usage instructions
-- Fixed documentation about handling newlines in GitHub commands
-
-## [1.4.2] - 2025-04-08
-
-### Changed
-
-- Renamed extension to "tana-tools-for-raycast" to avoid naming conflicts
-- Refactored complex date pattern regex into named components for improved readability and maintainability
-- Extracted magic indentation numbers to named constants
-- Enhanced code quality through better naming and organization
-
-## [1.4.1] - 2025-04-06
-
-### Changed
-
-- Cleaned up directory structure
-- Removed duplicate example files
-- Updated documentation approach
-
-## [1.4.0] - 2025-04-05
-
-### Fixed
-
-- Corrected indentation hierarchy for bullet points under deeper heading levels (H3+) (#11)
-- Improved handling of Limitless Pendant transcription indentation
-- Made output more robust by checking content and hierarchy
-
-## [1.3.0] - 2025-04-03
-
-### Added
-
-- Support for YouTube transcript timestamps as separate nodes in Tana (#4)
-
-### Fixed
-
-- Properly preserve bold text formatting in standard markdown (no longer converts to italic-underscore format) (#5)
-- Correct indentation hierarchy for numbered headings and their content (#5)
-- Improved error handling and stability
-
-## [1.1.0] - 2023-04-02
-
-### Added
-
-- Improved output formatting
-- Support for more complex Markdown formatting
-- Better handling of fields with colons
-- Proper preservation of URL syntax
-
-## [1.0.0] - 2023-03-15
-
-### Added
-
-- Initial release with main features:
-  - Convert Markdown bullet points to Tana nodes
-  - Support for headings as parent nodes
-  - Handle nested content with proper indentation
-  - Parse fields with colons and convert to Tana format
-  - Process inline formatting
-  - Support for timestamps
+## [1.0.0-beta] - 2025-05-24
 
 ### Features
 
-- Convert Markdown headings to Tana nodes with proper indentation
-- Intelligent field detection to distinguish between actual fields and regular text with colons
-- Preserve bracketed elements in text that shouldn't be converted to tags
-- Proper handling of URL and link syntax
-- Process inline formatting (bold, italic, highlights)
-- Convert dates to Tana's date format
-- Handle nested lists and indented content
-- Automatic opening of Tana after conversion
+- Convert clipboard or selected text to Tana Paste format
+- Edit and preview before converting
+- Extract and format YouTube video metadata and transcripts (with transcript chunking for large videos)
+- Supports Limitless Pendant and Limitless App transcriptions
+- Supports most Markdown transformations (headings, lists, paragraphs, nesting, etc.)
+- Clip the main content of any web page and instantly convert it to a clean, organized Tana outline
+- Add page title and URL as parent/child nodes when converting from web content
+- Add #swipe supertag automatically for web and selected content
+- Instant feedback via Raycast HUD

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ Quickly convert text, Markdown, YouTube, and Limitless content to Tana Paste for
 ## Features
 
 - Convert clipboard or selected text to Tana Paste format
+- Clip the main content of any web page and instantly convert it to a clean, organized Tana outline.
 - Edit and preview before converting
 - Extract and format YouTube video metadata and transcripts (with transcript chunking for large videos)
 - Supports Limitless Pendant and Limitless App transcriptions
 - Supports most Markdown transformations (headings, lists, paragraphs, nesting, etc.)
-- Instant feedback via Raycast HUD
-- If something isn't working as expected, please open an issue!
 
 ## Installation
 
@@ -25,20 +24,22 @@ Quickly convert text, Markdown, YouTube, and Limitless content to Tana Paste for
    npm install
    ```
 
-3. Build and start development:
+3. Build and start using (in development mode until we get it on the store):
 
    ```sh
    npm run build
    npm run dev
    ```
 
-## Usage
+## Commands
 
 - **Quick Clipboard to Tana:**
   1. Copy any text or Markdown to your clipboard (⌘+C).
   2. Open Raycast and run the "Quick Clipboard to Tana" command.
   3. The clipboard content is instantly scrubbed and converted to Tana Paste format.
   4. Paste into Tana (⌘+V).
+  
+  *How it works: The command takes whatever is on your clipboard, cleans up the formatting, and converts it into a Tana-ready outline you can paste directly into your workspace.*
 
 - **Paste and Edit for Tana:**
   1. Copy any text or Markdown to your clipboard (⌘+C).
@@ -51,12 +52,16 @@ Quickly convert text, Markdown, YouTube, and Limitless content to Tana Paste for
       ![Paste and Edit for Tana example](metadata/02_convert-open.png)
       *Example: Edit your clipboard content before converting to Tana Paste format*
 
+  *How it works: Lets you review and edit your clipboard content before it's converted, so you can make quick tweaks and see the result before sending it to Tana.*
+
 - **Convert Selected Text to Tana:**
   1. Highlight text in any application (web page, document, etc.).
   2. Open Raycast and run the "Convert Selected Text to Tana" command.
   3. If the selection is from a website, the output will use the page title as the parent node and add the URL as the first child node.
   4. The selected text is converted to Tana Paste format and copied to your clipboard.
   5. Paste into Tana (⌘+V).
+
+  *How it works: Automatically detects if your selection is from a web page, adds the page title and URL, and formats your selection for Tana Paste.*
 
 - **YouTube to Tana:**
   1. Go to a YouTube video page in your browser.
@@ -68,9 +73,20 @@ Quickly convert text, Markdown, YouTube, and Limitless content to Tana Paste for
       ![YouTube to Tana example output](metadata/04_youtube-tana-transcript.png)
       *Example: YouTube video transcript and metadata pasted into Tana*
 
+  *How it works: Extracts all available metadata and transcript from the YouTube page, organizes it into a Tana-friendly outline, and chunks long transcripts for easy pasting.*
+
 - **Limitless Pendant/App:** Paste or select Limitless transcriptions and convert them to Tana Paste format.
 
-Paste the result into Tana with ⌘+V.
+  *How it works: Recognizes Limitless transcription formats and converts them into a clean, structured Tana outline.*
+
+- **Copy Page Content to Tana Paste:**
+  1. Open a web page in your browser.
+  2. Open Raycast and run the "Copy Page Content to Tana Paste" command.
+  3. The command will extract all text from the current page, use the page title as the parent node, add the URL as a field, and add the #swipe supertag.
+  4. The result is converted to Tana Paste format and copied to your clipboard.
+  5. Paste into Tana (⌘+V).
+
+  *How it works: Extracts the main content of the web page (ignoring navigation, sidebars, and ads), excludes images, and organizes everything under the page title for a clean Tana import.*
 
 ## Example
 
@@ -92,11 +108,10 @@ Paste the result into Tana with ⌘+V.
 ## Technical
 
 - TypeScript, Raycast API v1.99.2
-- Functional programming, strict typing, error handling
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! Please feel free to submit a Pull Request. Open an issue if you want a feature.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.99.2",
+        "cheerio": "^1.0.0",
+        "turndown": "^7.2.0",
         "youtube-transcript": "^1.2.1"
       },
       "devDependencies": {
@@ -19,6 +21,7 @@
         "@types/node": "^18.8.3",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.1",
+        "@types/turndown": "^5.0.5",
         "eslint": "^9.23.0",
         "eslint-plugin-react": "^7.37.4",
         "globals": "^16.0.0",
@@ -581,6 +584,12 @@
         }
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -816,6 +825,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
+      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.32.1",
@@ -1311,6 +1327,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1427,6 +1449,48 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "license": "MIT"
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -1500,6 +1564,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -1647,6 +1739,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1682,6 +1829,43 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.23.10",
@@ -2582,6 +2766,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3310,6 +3513,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3513,6 +3728,55 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4206,6 +4470,15 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4365,6 +4638,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -4380,6 +4662,39 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,18 @@
       "title": "Youtube to Tana",
       "description": "Extract YouTube video information and convert to Tana Paste format",
       "mode": "no-view"
+    },
+    {
+      "name": "copy-page-content-to-tana",
+      "title": "Copy Page Content to Tana",
+      "description": "Extract all text from the current browser page and convert to Tana Paste format",
+      "mode": "no-view"
     }
   ],
   "dependencies": {
     "@raycast/api": "^1.99.2",
+    "cheerio": "^1.0.0",
+    "turndown": "^7.2.0",
     "youtube-transcript": "^1.2.1"
   },
   "devDependencies": {
@@ -44,6 +52,7 @@
     "@types/node": "^18.8.3",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.1",
+    "@types/turndown": "^5.0.5",
     "eslint": "^9.23.0",
     "eslint-plugin-react": "^7.37.4",
     "globals": "^16.0.0",

--- a/raycast-env.d.ts
+++ b/raycast-env.d.ts
@@ -21,6 +21,8 @@ declare namespace Preferences {
   export type SelectedToTana = ExtensionPreferences & {}
   /** Preferences accessible in the `youtube-to-tana` command */
   export type YoutubeToTana = ExtensionPreferences & {}
+  /** Preferences accessible in the `copy-page-content-to-tana` command */
+  export type CopyPageContentToTana = ExtensionPreferences & {}
 }
 
 declare namespace Arguments {
@@ -32,5 +34,7 @@ declare namespace Arguments {
   export type SelectedToTana = {}
   /** Arguments passed to the `youtube-to-tana` command */
   export type YoutubeToTana = {}
+  /** Arguments passed to the `copy-page-content-to-tana` command */
+  export type CopyPageContentToTana = {}
 }
 

--- a/src/copy-page-content-to-tana.tsx
+++ b/src/copy-page-content-to-tana.tsx
@@ -57,15 +57,15 @@ export default async function Command() {
     const turndownService = new TurndownService()
     turndownService.addRule('no-images', {
       filter: 'img',
-      replacement: () => ''
+      replacement: () => '',
     })
     const markdown = turndownService.turndown(pageHtml)
 
     // Indent markdown content while preserving structure
     const indentedMarkdown = markdown
       .split('\n\n') // Split by paragraphs instead of lines
-      .filter(paragraph => paragraph.trim() !== "")
-      .map(paragraph => `  - ${paragraph.replace(/\n/g, ' ')}`) // Join lines within paragraphs
+      .filter((paragraph) => paragraph.trim() !== '')
+      .map((paragraph) => `  - ${paragraph.replace(/\n/g, ' ')}`) // Join lines within paragraphs
       .join('\n')
 
     // Compose Tana input: root node, URL, then the indented main content
@@ -75,11 +75,8 @@ export default async function Command() {
     await showHUD('Copied page content to Tana Paste!')
 
     // Cross-platform open for tana://
-    const opener = os.platform() === 'darwin'
-      ? 'open'
-      : os.platform() === 'win32'
-        ? 'start'
-        : 'xdg-open'
+    const opener =
+      os.platform() === 'darwin' ? 'open' : os.platform() === 'win32' ? 'start' : 'xdg-open'
     await execAsync(`${opener} tana://`)
   } catch (error) {
     console.error(error)

--- a/src/copy-page-content-to-tana.tsx
+++ b/src/copy-page-content-to-tana.tsx
@@ -1,0 +1,84 @@
+import { showHUD, Clipboard, BrowserExtension } from '@raycast/api'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import { load } from 'cheerio'
+import TurndownService from 'turndown'
+import { convertToTana } from './utils/tana-converter'
+
+const execAsync = promisify(exec)
+
+export default async function Command() {
+  try {
+    let pageTitle = ''
+    let pageHtml = ''
+    let url = ''
+    const tabs = await BrowserExtension.getTabs()
+    const activeTab = tabs?.find((tab) => tab.active)
+    if (!activeTab) {
+      await showHUD('No active browser tab found.')
+      return
+    }
+    url = activeTab.url || ''
+    pageTitle = activeTab.title || 'Untitled Page'
+    try {
+      pageHtml = await BrowserExtension.getContent({
+        cssSelector: 'main',
+        format: 'html',
+        tabId: activeTab.id,
+      })
+    } catch {
+      try {
+        pageHtml = await BrowserExtension.getContent({
+          cssSelector: 'article',
+          format: 'html',
+          tabId: activeTab.id,
+        })
+      } catch {
+        try {
+          pageHtml = await BrowserExtension.getContent({
+            cssSelector: 'body',
+            format: 'html',
+            tabId: activeTab.id,
+          })
+        } catch (error2) {
+          console.error('Error getting page HTML:', error2)
+          await showHUD('Unable to get page HTML. Please try again.')
+          return
+        }
+      }
+    }
+
+    // Use Cheerio to select the main content
+    const $ = load(pageHtml)
+    const mainElemHtml = $('main').html() || $('article').html() || $('body').html() || ''
+    if (!mainElemHtml) {
+      await showHUD('Unable to extract main content.')
+      return
+    }
+
+    // Use Turndown to convert HTML to Markdown, but ignore images
+    const turndownService = new TurndownService()
+    turndownService.addRule('no-images', {
+      filter: 'img',
+      replacement: () => '',
+    })
+    const markdown = turndownService.turndown(mainElemHtml)
+
+    // Indent all markdown lines as children of the root node
+    const indentedMarkdown = markdown
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => `  - ${line}`)
+      .join('\n')
+
+    // Compose Tana input: root node, URL, then the indented main content
+    const tanaInput = `- ${pageTitle} #swipe\n  - URL::${url}\n${indentedMarkdown}`
+    const tanaPaste = convertToTana(tanaInput)
+    await Clipboard.copy(tanaPaste)
+    await showHUD('Copied page content to Tana Paste!')
+    await execAsync('open tana://')
+  } catch (error) {
+    console.error(error)
+    await showHUD('Error: ' + (error as Error).message)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the 'Copy Page Content to Tana Paste' command: clips main content from any web page and converts it to a clean, organized Tana outline.
- Excludes images and ensures all content is properly nested under the page title.
- Updates README for user-focused usage and workflow, with per-command 'How it works' explanations.
- Consolidates changelog into a single beta release listing all major features.
- Removes unused dependencies and improves extension performance.

Ready for review and merge to main for beta release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command to extract and convert the main content of any web page into a clean Tana Paste outline, including the page title, URL, and a #swipe supertag.
  - Added support for copying web page content directly to the clipboard in Tana format.

- **Documentation**
  - Updated the README with detailed instructions for the new web clipping feature and improved command descriptions.
  - Revised installation and contributing guidelines for clarity.

- **Chores**
  - Overhauled the changelog to summarize all features in a single entry, removing previous version history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->