### PR TITLE
Hotfix: Exclude script and style content from copy page content command output

### DIFF
--- a/src/copy-page-content-to-tana.tsx
+++ b/src/copy-page-content-to-tana.tsx
@@ -4,6 +4,7 @@ import { promisify } from 'util'
 import os from 'os'
 import TurndownService from 'turndown'
 import { convertToTana } from './utils/tana-converter'
+import * as cheerio from 'cheerio'
 
 const execAsync = promisify(exec)
 
@@ -53,13 +54,18 @@ export default async function Command() {
       return
     }
 
+    // Remove <script> and <style> tags using Cheerio
+    const $ = cheerio.load(pageHtml)
+    $('script, style').remove()
+    const cleanedHtml = $.html()
+
     // Use Turndown to convert HTML to Markdown, but ignore images
     const turndownService = new TurndownService()
     turndownService.addRule('no-images', {
       filter: 'img',
       replacement: () => '',
     })
-    const markdown = turndownService.turndown(pageHtml)
+    const markdown = turndownService.turndown(cleanedHtml)
 
     // Indent markdown content while preserving structure
     const indentedMarkdown = markdown


### PR DESCRIPTION
This PR addresses issue #45. It uses Cheerio to remove all <script> and <style> tags from the HTML before converting it to Markdown in the 'Copy Page Content to Tana Paste' command. This ensures that unwanted JavaScript and CSS content is not included in the copied output. Changes: - Updated the import for Cheerio to use the ESM-compatible style. - Added Cheerio-based cleanup to strip out script and style tags from the HTML. Please review and merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown export by ensuring that script and style elements are excluded from the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->